### PR TITLE
Ec add ostrich

### DIFF
--- a/docs/ec-add-ostrich_Pull-Request.md
+++ b/docs/ec-add-ostrich_Pull-Request.md
@@ -1,0 +1,37 @@
+# Description
+
+User is now able to add ostrich to a given grazing field - user can also add a duck house and subsequently ducks.
+There is a bug that I'd like to go over with everyone.
+Before I could make it possible for the user to add a duck, I had to change the logic in "purchase stock option".
+This means that if a user has a duck house but no grazing field, it's still possible for the user to enter the
+"purchase stock" option. At which point the program breaks if the user tries to purchase any grazing animals.
+If you guys look at the switch case to purchase a duck I've added logic that tells the user they can't purchase a duck
+without a duck house - and returns them to the main menu. We could implement this for all case numbers but
+I wanted everyone to see it first in case there's a more effiecient way - one thought I had was a dynamically populated
+list that would only include options that fit what resources the user has. but idk.
+
+
+Fixes # user can purchase - ostrich, ducks, duckhouse
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+# Testing Instructions
+
+Testing would include purchasing a facility either for duck or ostrich. And then placing a duck or ostrich
+respectively. Existing bug listed in description. Purchasing a duck house lets the user into purchase stock,
+if anything that belongs in a grazing field is selected program breaks.
+
+
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added test instructions that prove my fix is effective or that my feature works

--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Trestlebridge.Interfaces;
+using Trestlebridge.Models;
+using Trestlebridge.Models.Animals;
+
+namespace Trestlebridge.Actions
+{
+    public class ChooseDuckHouse
+    {
+        public static void CollectInput(Farm farm, IGrazing animal)
+        {
+            Console.Clear();
+
+            for (int i = 0; i < farm.DuckHouses.Count; i++)
+            {
+                Console.WriteLine($"{i + 1}. Duck House");
+            }
+
+            Console.WriteLine();
+
+            // How can I output the type of animal chosen here?
+            Console.WriteLine($"Place the animal where?");
+
+            Console.Write("> ");
+            int choice = Int32.Parse(Console.ReadLine());
+
+            farm.DuckHouses[choice - 1].AddResource(animal);
+
+            /*
+                Couldn't get this to work. Can you?
+                Stretch goal. Only if the app is fully functional.
+             */
+            // farm.PurchaseResource<IGrazing>(animal, choice);
+
+        }
+    }
+}

--- a/src/Actions/CreateFacility.cs
+++ b/src/Actions/CreateFacility.cs
@@ -11,6 +11,7 @@ namespace Trestlebridge.Actions
         {
             Console.WriteLine("1. Grazing field");
             Console.WriteLine("2. Plowed field");
+            Console.WriteLine("5. Duck House");
 
             Console.WriteLine();
             Console.WriteLine("Choose what you want to create");
@@ -25,6 +26,9 @@ namespace Trestlebridge.Actions
                     break;
                 case 2:
                     farm.AddPlowedField(new PlowedField());
+                    break;
+                case 5:
+                    farm.AddDuckHouse(new DuckHouse());
                     break;
                 default:
                     break;

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -16,6 +16,7 @@ namespace Trestlebridge.Actions
             Console.WriteLine("4. Sheep");
             Console.WriteLine("5. Pig");
             Console.WriteLine("6. Dragon");
+            Console.WriteLine("7. Duck");
             Console.WriteLine();
             Console.WriteLine("What are you buying today?");
 
@@ -42,6 +43,21 @@ namespace Trestlebridge.Actions
                 // case 6:
                 //     ChooseGrazingField.CollectInput(farm, new Dragon());
                 //     break;
+                case 7:
+                    //! This logic only allow purchase of a duck if Duck House exists, and otherwise returns them to the main menu.
+                    if (farm.DuckHouses.Count != 0)
+                    {
+                        ChooseDuckHouse.CollectInput(farm, new Duck());
+                        break;
+                    }
+                    else
+                    {
+                        Console.Clear();
+                        Console.WriteLine("You ain't got no duck house!");
+                        Console.WriteLine("Press enter, idget!");
+                        Console.ReadLine();
+                        break;
+                    }
                 default:
                     break;
             }

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -44,6 +44,7 @@ namespace Trestlebridge.Actions
                 //     ChooseGrazingField.CollectInput(farm, new Dragon());
                 //     break;
                 case 7:
+
                     //! This logic only allow purchase of a duck if Duck House exists, and otherwise returns them to the main menu.
                     if (farm.DuckHouses.Count != 0)
                     {

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -27,9 +27,9 @@ namespace Trestlebridge.Actions
                 case 1:
                     ChooseGrazingField.CollectInput(farm, new Cow());
                     break;
-                // case 2:
-                //     ChooseGrazingField.CollectInput(farm, new Ostrich());
-                //     break;
+                case 2:
+                    ChooseGrazingField.CollectInput(farm, new Ostrich());
+                    break;
                 // case 3:
                 //     ChooseGrazingField.CollectInput(farm, new Goat());
                 //     break;

--- a/src/Models/Animals/Duck.cs
+++ b/src/Models/Animals/Duck.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Trestlebridge.Interfaces;
+
+public class Duck : IResource, IGrazing
+{
+    // Fields
+    private Guid _id;
+
+
+    // Properties
+
+
+    // Constructor
+    public Duck()
+    {
+        _id = Guid.NewGuid();
+    }
+
+    private string _shortId
+    {
+        get
+        {
+            return this._id.ToString().Substring(this._id.ToString().Length - 6);
+        }
+    }
+
+
+    // Methods
+    // public double Process(MeatProcessor equipment)
+    // {
+    //     return 1.7;
+    // }
+
+    // public double Process(EggGatherer equipment)
+    // {
+    //     return 7;
+    // }
+
+    // public double Process(FeatherHarvester equipment)
+    // {
+    //     return 0.5;
+    // }
+
+    public override string ToString()
+    {
+        return $"Duck {_shortId}. Quack!! Quack!! Quack!! Quack!!";
+    }
+
+    public double GrassPerDay { get; set; } = .8;
+    public string Type { get; } = "Duck";
+
+    // Methods
+    public void Graze()
+    {
+        Console.WriteLine($"Duck {this._shortId} just ate {this.GrassPerDay}kg of grass");
+    }
+}

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Trestlebridge.Interfaces;
+
+
+namespace Trestlebridge.Models.Facilities
+{
+    public class DuckHouse : IFacility<IGrazing>
+    {
+        private int _capacity = 50;
+        private Guid _id = Guid.NewGuid();
+
+        private List<IGrazing> _ducks = new List<IGrazing>();
+
+        public double Capacity
+        {
+            get
+            {
+                return _capacity;
+            }
+        }
+
+        public void AddResource(IGrazing animal)
+        {
+            // TODO: implement this...
+            _ducks.Add(animal);
+        }
+
+        public void AddResource(List<IGrazing> animals)
+        {
+            // TODO: implement this...
+            Console.WriteLine("This should do something @ GrazingField AddResource");
+        }
+
+        public override string ToString()
+        {
+            StringBuilder output = new StringBuilder();
+            string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
+
+            output.Append($"Duck House {shortId} has {this._ducks.Count} animals\n");
+            this._ducks.ForEach(a => output.Append($"   {a}\n"));
+
+            return output.ToString();
+        }
+    }
+}

--- a/src/Models/Farm.cs
+++ b/src/Models/Farm.cs
@@ -10,6 +10,7 @@ namespace Trestlebridge.Models
     {
         public List<GrazingField> GrazingFields { get; } = new List<GrazingField>();
         public List<PlowedField> PlowedFields { get; } = new List<PlowedField>();
+        public List<DuckHouse> DuckHouses { get; } = new List<DuckHouse>();
 
         /*
             This method must specify the correct product interface of the
@@ -38,12 +39,18 @@ namespace Trestlebridge.Models
             PlowedFields.Add(field);
         }
 
+        public void AddDuckHouse(DuckHouse duckhouse)
+        {
+            DuckHouses.Add(duckhouse);
+        }
+
         public override string ToString()
         {
             StringBuilder report = new StringBuilder();
 
             GrazingFields.ForEach(gf => report.Append(gf));
             PlowedFields.ForEach(gf => report.Append(gf));
+            DuckHouses.ForEach(dh => report.Append(dh));
 
             return report.ToString();
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -48,7 +48,7 @@ namespace Trestlebridge
                 }
                 else if (option == "2")
                 {
-                    if (Trestlebridge.GrazingFields.Count != 0)
+                    if (Trestlebridge.GrazingFields.Count != 0 || Trestlebridge.DuckHouses.Count != 0)
                     {
                         DisplayBanner();
                         PurchaseStock.CollectInput(Trestlebridge);


### PR DESCRIPTION
# Description

User is now able to add ostrich to a given grazing field - user can also add a duck house and subsequently ducks. 

There is a bug that I'd like to go over with everyone. Before I could make it possible for the user to add a duck, I had to change the logic in "purchase stock option". This means that if a user has a duck house but no grazing field, it's still possible for the user to enter the "purchase stock" option. At which point the program breaks if the user tries to purchase any grazing animals. 

If you guys look at the switch case to purchase a duck I've added logic that tells the user they can't purchase a duck without a duck house - and returns them to the main menu. We could implement this for all case numbers but I wanted everyone to see it first in case there's a more efficient way - one thought I had was a dynamically populated list that would only include options that fit what resources the user has. but idk.

Fixes # (issue)

## Type of change -- user can purchase - ostrich, ducks, duckhouse

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing Instructions

Testing would include purchasing a facility either for duck or ostrich. And then placing a duck or ostrich respectively. Existing bug listed in the description. Purchasing a duck house lets the user into purchase stock; if anything that belongs in a grazing field is selected program breaks.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
